### PR TITLE
SSH fixture reliability patch

### DIFF
--- a/src/pytest_netdut/factories.py
+++ b/src/pytest_netdut/factories.py
@@ -120,9 +120,7 @@ def create_skipper_fixture(name):
                         pattern = marker.args[0]
                         sku = request.getfixturevalue(f"{name}_sku")
                         if not re.search(pattern, sku):
-                            pytest.skip(
-                                f"Skipped on this SKU: {sku} (only runs on {pattern})"
-                            )
+                            pytest.skip(f"Skipped on this SKU: {sku} (only runs on {pattern})")
 
                     elif marker.name == "skip_device_type":
                         pattern = marker.args[0]

--- a/src/pytest_netdut/factories.py
+++ b/src/pytest_netdut/factories.py
@@ -19,6 +19,8 @@ import re
 import pytest
 from packaging import version
 from .wrappers import CLI, xapi
+import time
+import traceback
 
 logger = logging.getLogger(__name__)
 

--- a/src/pytest_netdut/factories.py
+++ b/src/pytest_netdut/factories.py
@@ -211,6 +211,7 @@ def retry(retries):
             while retries_:
                 try:
                     result = fn(*args, **kwargs)
+                    break
                 except Exception as e:
                     retries_ -= 1
                     logging.error(
@@ -219,6 +220,7 @@ def retry(retries):
                         retries_,
                         e,
                     )
+            return result
 
         return wrapper
 

--- a/src/pytest_netdut/factories.py
+++ b/src/pytest_netdut/factories.py
@@ -19,6 +19,7 @@ import re
 import pytest
 from packaging import version
 from .wrappers import CLI, xapi
+from functools import wraps
 
 logger = logging.getLogger(__name__)
 

--- a/src/pytest_netdut/factories.py
+++ b/src/pytest_netdut/factories.py
@@ -1,5 +1,5 @@
 # -------------------------------------------------------------------------------
-# - Copyright (c) 2021 Arista Networks, Inc. All rights reserved.
+# - Copyright (c) 2021-2024 Arista Networks, Inc. All rights reserved.
 # -------------------------------------------------------------------------------
 # - Author:
 # -   fdk-support@arista.com
@@ -120,7 +120,9 @@ def create_skipper_fixture(name):
                         pattern = marker.args[0]
                         sku = request.getfixturevalue(f"{name}_sku")
                         if not re.search(pattern, sku):
-                            pytest.skip(f"Skipped on this SKU: {sku} (only runs on {pattern})")
+                            pytest.skip(
+                                f"Skipped on this SKU: {sku} (only runs on {pattern})"
+                            )
 
                     elif marker.name == "skip_device_type":
                         pattern = marker.args[0]
@@ -199,6 +201,7 @@ def create_softened_fixture(name):
 
     return _softened
 
+
 def retry(retries):
     def decorator(fn):
         @wraps(fn)
@@ -208,16 +211,19 @@ def retry(retries):
             while retries_:
                 try:
                     result = fn(*args, **kwargs)
-                    break
                 except Exception as e:
                     retries_ -= 1
-                    logging.error("An error occurred in %s, retries left %d: %s", fn.__name__, retries_, e)
-            return result
+                    logging.error(
+                        "An error occurred in %s, retries left %d: %s",
+                        fn.__name__,
+                        retries_,
+                        e,
+                    )
 
         return wrapper
-        
+
     return decorator
-    
+
 
 class _CLI_wrapper:
     _cli = None

--- a/src/pytest_netdut/factories.py
+++ b/src/pytest_netdut/factories.py
@@ -220,7 +220,9 @@ class _CLI_wrapper:
                     except Exception as e:
                         retries_ -= 1
                         logging.error("An error occurred in %s, retries left %d, %s", fn.__name__, retries_, e)
+
             return wrapper
+
         return decorator
 
     def close_and_re_init(self):
@@ -232,7 +234,7 @@ class _CLI_wrapper:
     def close(self, *args, **kwargs):
         return self._cli.close(*args, **kwargs)
 
-    @retry(retries=3)
+    @retry(3)
     def login(self, *args, **kwargs):
         return self._cli.login(*args, **kwargs)
 
@@ -323,6 +325,7 @@ def create_ssh_fixture(name):
             except AttributeError:
                 pass
         yield ssh
+
     return _ssh
 
 

--- a/src/pytest_netdut/px.py
+++ b/src/pytest_netdut/px.py
@@ -150,7 +150,7 @@ class CLI(Shell):
         self.cmd = o.scheme
         if self.cmd == "ssh":
             self.args = ["%s@%s" % (username, o.hostname)]
-            self.args += ["-o LogLevel ERROR"]
+            self.args += ["-o LogLevel DEBUG3"]
             self.args += ["-o ConnectionAttempts 10"]
             self.args += ["-o StrictHostKeyChecking no"]
             self.args += ["-o UserKnownHostsFile /dev/null"]


### PR DESCRIPTION
Add retries to the SSH fixture and fail test. Otherwise raising exceptions in the fixture causes the fixture to drop from the fixture context and spawn up recursion errors.